### PR TITLE
fix: hardcode kernel header version

### DIFF
--- a/week2/README.md
+++ b/week2/README.md
@@ -39,7 +39,7 @@ ssh myvm
 ## 3. Provision the VM
 ```
 sudo apt-get update
-sudo apt-get install build-essential git vim-nox linux-headers-4.19.0-9-amd64
+sudo apt-get install build-essential git vim-nox linux-headers-$(uname -r)
 ```
 
 ## 4. Hello World in the OS kernel


### PR DESCRIPTION
The kernel version changes over time, it is now 4.19.0-18-amd64. One solution is deprecating the hard code.